### PR TITLE
Add ratings and correct updatedAt timestamps for several services

### DIFF
--- a/content/services/chevereto.md
+++ b/content/services/chevereto.md
@@ -8,10 +8,11 @@ tags:
   - PHP
   - 媒体
   - 自托管
+rating: 4
 category: 图像托管
 website: 'https://chevereto.com'
 repo: 'https://github.com/chevereto/chevereto'
-updatedAt: '2025-05-10T14:00:00.000Z'
+updatedAt: '2026-01-03T00:00:00.000Z'
 ---
 
 Chevereto 是一个成熟稳定的自托管图片和视频分享平台，自 2007 年以来一直受到用户信赖。它允许您构建自己的 Flickr 或 Imgur 风格的媒体分享平台，完全控制您的内容、数据和平台规则。

--- a/content/services/cloudreve.md
+++ b/content/services/cloudreve.md
@@ -7,10 +7,11 @@ tags:
   - 文件共享
   - Go
   - 云存储
+rating: 4
 category: 文件管理
 website: 'https://cloudreve.org'
 repo: 'https://github.com/cloudreve/Cloudreve'
-updatedAt: '2025-05-08T21:43:18.211Z'
+updatedAt: '2026-01-03T00:00:00.000Z'
 ---
 
 Cloudreve 是一个支持多种云存储的网盘系统，支持本地存储、对象存储和云存储。它提供了丰富的文件管理功能，支持多用户、多存储策略，是一个功能完整的自托管网盘解决方案。

--- a/content/services/gitea-mirror.md
+++ b/content/services/gitea-mirror.md
@@ -7,10 +7,11 @@ tags:
   - 同步
   - 备份
   - 自动化
+rating: 3.5
 category: 代码托管
 website: 'https://github.com/RayLabsHQ/gitea-mirror'
 repo: 'https://github.com/RayLabsHQ/gitea-mirror'
-updatedAt: '2025-05-12T00:00:00.000Z'
+updatedAt: '2026-01-06T00:00:00.000Z'
 ---
 
 Gitea Mirror 用于将外部 Git 仓库镜像到 Gitea，并保持持续同步，便于集中管理、备份与迁移。

--- a/content/services/remark42.md
+++ b/content/services/remark42.md
@@ -7,10 +7,11 @@ tags:
   - 博客
   - Go
   - Docker
+rating: 3.5
 category: 内容管理系统
 website: 'https://remark42.com/'
 repo: 'https://github.com/umputun/remark42'
-updatedAt: '2025-05-12T00:00:00.000Z'
+updatedAt: '2026-01-06T00:00:00.000Z'
 ---
 
 Remark42 是一个轻量级的自托管评论引擎，强调隐私与易部署，可嵌入博客、文档或产品页面。


### PR DESCRIPTION
### Motivation
- Record explicit `rating` metadata for service entries to capture evaluation scores. 
- Correct incorrect `updatedAt` timestamps and align them to the intended dates. 
- Keep metadata edits confined to frontmatter to maintain content consistency. 
- Address inline comment requesting `chevereto` and `cloudreve` `updatedAt` be set to `2026-01-03T00:00:00.000Z`.

### Description
- Added `rating: 4` to `content/services/chevereto.md` and `content/services/cloudreve.md`. 
- Added `rating: 3.5` to `content/services/gitea-mirror.md` and `content/services/remark42.md`. 
- Fixed `updatedAt` in `content/services/gitea-mirror.md` and `content/services/remark42.md` to `2026-01-06T00:00:00.000Z`. 
- Updated `updatedAt` in `content/services/chevereto.md` and `content/services/cloudreve.md` to `2026-01-03T00:00:00.000Z` and normalized a trailing newline in `content/services/chevereto.md`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a09a13ae483339aebb39977caaa9f)