### PR TITLE
fix: pin pnpm for Docker builds

### DIFF
--- a/.github/workflows/build-main-docker-to-acr.yml
+++ b/.github/workflows/build-main-docker-to-acr.yml
@@ -50,7 +50,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             PUSH_RECENT=1
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            gh_token=${{ secrets.GH_TOKEN }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.get_version.outputs.VERSION }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/dev-docker-to-acr.yml
+++ b/.github/workflows/dev-docker-to-acr.yml
@@ -49,7 +49,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             PUSH_ALL=0
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            gh_token=${{ secrets.GH_TOKEN }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:devel
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,30 @@
+# syntax=docker/dockerfile:1.7
+
 # Build stage
 FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Install a Node 20 compatible pnpm version. Avoid pnpm@latest, which may require newer Node built-ins.
+ARG PNPM_VERSION=10.28.1
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml ./
 
 # Install dependencies
-RUN env && pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 # Copy source code
 COPY . .
-
-# Set environment variables for build time
-ARG GH_TOKEN
-ENV GH_TOKEN=${GH_TOKEN}
 
 # Build application with optional IndexNow push
 ARG PUSH_ALL=0
 ARG PUSH_RECENT=0
 
-RUN if [ "$PUSH_ALL" = "1" ]; then \
+RUN --mount=type=secret,id=gh_token \
+    export GH_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)"; \
+    if [ "$PUSH_ALL" = "1" ]; then \
     pnpm build && pnpm push:all || true; \
     elif [ "$PUSH_RECENT" = "1" ]; then \
     pnpm build && pnpm push:recent || true; \
@@ -36,8 +37,9 @@ FROM node:20-alpine AS runner
 
 WORKDIR /app
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Install a Node 20 compatible pnpm version. Avoid pnpm@latest, which may require newer Node built-ins.
+ARG PNPM_VERSION=10.28.1
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml ./

--- a/package.json
+++ b/package.json
@@ -92,5 +92,6 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.4",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@10.28.1"
 }


### PR DESCRIPTION
### Motivation
- Docker builds were failing inside BuildKit with `ERR_UNKNOWN_BUILTIN_MODULE` because `pnpm@latest` pulled a pnpm release that requires newer Node built-ins than Node 20.\n- `GH_TOKEN` was passed as a build `ARG` and `ENV`, causing a `SecretsUsedInArgOrEnv` warning and risk of leaking secrets into image layers.\n- The Dockerfile printed the environment during install which exposed unnecessary data in CI logs.

### Description
- Pin `pnpm` to `10.28.1` for both builder and runner by adding `ARG PNPM_VERSION=10.28.1` and using `corepack prepare pnpm@${PNPM_VERSION}`.\n- Add `packageManager: "pnpm@10.28.1"` to `package.json` so local/corepack resolution is consistent with the image.\n- Remove the `env &&` debug dump from the Docker install step.\n- Pass `GH_TOKEN` to the build as a BuildKit secret using `--mount=type=secret,id=gh_token` in the Dockerfile and update GitHub Actions to supply `gh_token` via the `secrets:` stanza instead of a build `ARG`.

### Testing
- Ran `pnpm install --frozen-lockfile` locally and it completed successfully.\n- Verified `corepack prepare pnpm@10.28.1 --activate && pnpm install --prod --frozen-lockfile` in a clean temporary directory and it succeeded.\n- Ran `pnpm build` locally but the Next.js build failed due to inability to fetch Google Fonts (network issue), which is unrelated to the pnpm/Docker fixes.\n- Could not run `docker build` locally in this environment because the Docker CLI is not installed, so CI build is required to fully validate the image build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2277ccea248333b1bbb8a7a1c67f64)