### PR TITLE
Add Hivekeep

### DIFF
--- a/content/services-en/hivekeep.md
+++ b/content/services-en/hivekeep.md
@@ -1,0 +1,34 @@
+---
+id: hivekeep
+name: Hivekeep
+description: Self-hosted platform to run a team of specialized AI agents with persistent memory and a web UI.
+tags:
+  - AI
+  - LLM
+  - Agents
+  - TypeScript
+  - Docker
+rating: 4.0
+category: Generative Artificial Intelligence (GenAI)
+website: 'https://hivekeep.app'
+repo: 'https://github.com/MarlBurroW/hivekeep'
+updatedAt: '2026-06-29T08:00:00.000Z'
+---
+
+Hivekeep is a self-hosted platform to run a team of specialized AI agents that collaborate, share persistent memory, and build their own tools, mini-apps, and plugins. It ships with a web UI and can be reached over Telegram, Slack, Discord, and Matrix, all from a single container.
+
+## Key Features
+
+- **Team of agents**: Run multiple specialized agents that collaborate and delegate tasks to each other
+- **Persistent memory**: Long-term memory shared across agents and conversations
+- **Self-extending**: Agents build their own tools, mini-apps, and plugins
+- **Multi-channel**: Reachable over Telegram, Slack, Discord, and Matrix in addition to the web UI
+- **Provider-agnostic**: Works with cloud LLM providers or local models via an OpenAI-compatible API
+- **Single container**: Runs as one Docker container (Bun + SQLite), no external database required
+
+## Deployment Requirements
+
+- Docker deployment supported (official image available)
+- OS: Linux, macOS, Windows
+- Storage: SQLite, no external database required
+- Configuration: web-based onboarding wizard

--- a/content/services/hivekeep.md
+++ b/content/services/hivekeep.md
@@ -1,0 +1,34 @@
+---
+id: hivekeep
+name: Hivekeep
+description: 自托管平台，运行一支具备持久记忆和 Web 界面的专业 AI 智能体团队。
+tags:
+  - AI
+  - LLM
+  - 智能体
+  - TypeScript
+  - Docker
+rating: 4.0
+category: AI工具
+website: 'https://hivekeep.app'
+repo: 'https://github.com/MarlBurroW/hivekeep'
+updatedAt: '2026-06-29T08:00:00.000Z'
+---
+
+Hivekeep 是一个自托管平台，可运行一支由多个专业 AI 智能体组成的团队。它们相互协作、共享持久记忆，并能自行构建工具、迷你应用和插件。Hivekeep 自带 Web 界面，并可通过 Telegram、Slack、Discord 和 Matrix 访问，全部运行在单个容器中。
+
+## 主要功能
+
+- **智能体团队**：运行多个专业智能体，相互协作并分配任务
+- **持久记忆**：跨智能体和对话共享的长期记忆
+- **自我扩展**：智能体可自行构建工具、迷你应用和插件
+- **多渠道接入**：除 Web 界面外，还支持 Telegram、Slack、Discord、Matrix
+- **模型无关**：支持云端 LLM 服务商，或通过 OpenAI 兼容接口接入本地模型
+- **单容器部署**：以单个 Docker 容器运行（Bun + SQLite），无需外部数据库
+
+## 部署要求
+
+- 支持 Docker 一键部署（官方提供镜像）
+- 操作系统：Linux、macOS、Windows
+- 存储空间：SQLite，无需外部数据库
+- 配置方式：基于 Web 的引导式安装向导


### PR DESCRIPTION
Adds Hivekeep as a bilingual service entry (content/services-en/hivekeep.md + content/services/hivekeep.md), following the existing front-matter format (id, name, description, tags, rating, category, website, repo, updatedAt) plus a Key Features and Deployment Requirements section, mirroring the Gatus entry.

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins; reachable over Telegram, Slack, Discord and Matrix; single container (Bun + SQLite). Category: GenAI.

Disclosure: I am the author of Hivekeep.