### PR TITLE
Add OpenPost to the self-hosted catalog

### DIFF
--- a/content/services-en/openpost.md
+++ b/content/services-en/openpost.md
@@ -1,0 +1,15 @@
+---
+id: "openpost"
+name: "OpenPost"
+description: "Open-source, self-hosted social publishing platform for drafting, reviewing, scheduling, and publishing content across multiple social networks."
+tags:
+  - "AGPL-3.0"
+  - "Go"
+  - "Svelte"
+  - "Docker"
+category: "Analytics"
+website: "https://openpost.social"
+repo: "https://github.com/rodrgds/openpost"
+#image: "/placeholder.svg?height=300&width=400"
+---
+


### PR DESCRIPTION
Adds OpenPost alongside the existing Postiz and Mixpost entries in the English self-hosted catalog. OpenPost is an AGPL-3.0 social publishing platform with an official Docker deployment.

Validation: frontmatter parsed successfully, links checked, and `git diff --check` passed.

Disclosure: I maintain OpenPost.