### PR TITLE
chore: update OpenPost repository URL

### DIFF
--- a/content/services-en/openpost.md
+++ b/content/services-en/openpost.md
@@ -9,7 +9,7 @@ tags:
   - "Docker"
 category: "Analytics"
 website: "https://openpost.social"
-repo: "https://github.com/rodrgds/openpost"
+repo: "https://github.com/getopenpost/openpost"
 #image: "/placeholder.svg?height=300&width=400"
 ---
 


### PR DESCRIPTION
OpenPost moved from `rodrgds/openpost` to `getopenpost/openpost`. This updates the maintained listing to the canonical repository; GitHub currently redirects the old URL, but the new URL avoids relying on that compatibility redirect.