### PR TITLE
Add MailKite Server to the self-hosted catalog

### DIFF
--- a/content/services-en/mailkite-server.md
+++ b/content/services-en/mailkite-server.md
@@ -1,0 +1,13 @@
+---
+id: "mailkite-server"
+name: "MailKite Server"
+description: "Programmable mail server for apps and AI agents: Haraka-based SMTP MX and submission edges, an IMAP server, and a web console with a zero-dependency SQLite backend."
+tags:
+  - "AGPL-3.0"
+  - "Node.js"
+  - "Haraka"
+category: "Communication"
+website: "https://mailkite.dev/open-source"
+repo: "https://github.com/mailkite/server"
+#image: "/placeholder.svg?height=300&width=400"
+---


### PR DESCRIPTION
Adds MailKite Server (https://github.com/mailkite/server), an open-source AGPL-3.0 programmable mail server for apps and AI agents: Haraka-based SMTP MX and submission edges, an IMAP server, and a web console, with a zero-dependency SQLite backend. It is early-stage (pre-1.0, first release 2026-08-01) and runs on Node.js ≥ 22.5, so it is a genuinely new addition rather than a mature one — happy to adjust the wording if the list prefers more established projects only.